### PR TITLE
Mayhem Heroes Pull Request

### DIFF
--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -1,0 +1,58 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: '${{ matrix.os }} shared=${{ matrix.shared }} ${{ matrix.build_type }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        shared: [false]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Start analysis
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }}
+          sarif-output: sarif
+
+      - name: Upload SARIF file(s)
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use Rust to build
+FROM rustlang/rust:nightly as builder
+
+# Add source code to the build stage.
+ADD . /biscuit
+WORKDIR /biscuit
+
+RUN cargo install cargo-fuzz
+
+# BUILD INSTRUCTIONS
+WORKDIR /biscuit/fuzz
+RUN cargo +nightly fuzz build fuzz_decryption
+# Output binary is placed in /biscuit/fuzz/target/x86_64-unknown-linux-gnu/release/decode
+
+# Package Stage -- we package for a plain Ubuntu machine
+FROM --platform=linux/amd64 ubuntu:20.04
+
+## Install build dependencies.
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y gcc clang cmake
+
+## Copy the binary from the build stage to an Ubuntu docker image
+COPY --from=builder /biscuit/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_decryption /

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -1,0 +1,5 @@
+project: biscuit
+target: fuzz_decryption
+
+cmds:
+  - cmd: /fuzz_decryption

--- a/src/jws/flattened.rs
+++ b/src/jws/flattened.rs
@@ -146,6 +146,7 @@ impl Signable {
 #[derive(Clone)]
 pub struct SignedData {
     data: Signable,
+    #[allow(dead_code)]
     secret: Secret,
     signature: Vec<u8>,
 }

--- a/src/jws/flattened.rs
+++ b/src/jws/flattened.rs
@@ -146,7 +146,7 @@ impl Signable {
 #[derive(Clone)]
 pub struct SignedData {
     data: Signable,
-    #[allow(dead_code)]
+    #[warn(dead_code)]
     secret: Secret,
     signature: Vec<u8>,
 }


### PR DESCRIPTION
Added integration of Mayhem fuzzing to the `biscuit` project.

Integration was straightforward, as binaries for fuzzing were already created by the original maintainers. A Dockerfile to create the fuzzing binary, Mayhemfile, and Mayhem GitHub action were all added.

One minor change was added to the project to allow compilation, as a component in the `flattened.rs` file throws a `dead_code` linting error on compilation. This seems to be a project-wide issue occurring when compiling in general (not just for fuzzing), though it may be caused by the Rust nightly build. Compiler flags to change the `dead_code` linting to be a warning did not work, so a quick hack was added to the code to allow compilation. This fix likely isn't sustainable long-term, but at least allows compilation of the binaries.